### PR TITLE
Bumb com.criteriastudio.RemoteImageView Version

### DIFF
--- a/app/widgets/com.criteriastudio.RemoteImageView/widget.json
+++ b/app/widgets/com.criteriastudio.RemoteImageView/widget.json
@@ -3,7 +3,7 @@
 	"name": "com.criteriastudio.RemoteImageView",
 	"description" : "Downloads and caches images automatically",
 	"author": "Javier Rayon",
-	"version": "1.0",
+	"version": "1.1",
 	"copyright":"Copyright (c) 2012",
 	"license":"Public Domain",
 	"min-alloy-version": "1.0",


### PR DESCRIPTION
I think it'll update file there
http://gitt.io/component/com.criteriastudio.RemoteImageView

Right now install from `gittio` still give you syntax error in zoomWin.xml
`gittio install com.criteriastudio.RemoteImageView`
