### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to your xml files and 100% customizables from style files.
 
 Find more info about ux mobile patterns in our website [www.uxmobilepatterns.com](http://www.uxmobilepatterns.com) or contact us by twitter at @jrayon and @sonianoneka
 
-##Multiplatform Support
+## Multiplatform Support
 
 The project has been developed for and fully works on iPhone. Although the UX has been designed with iPhone users in mind, most components also work on android
 and our intention is to give full support to the templates and widgets working in both platforms.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
